### PR TITLE
Add path argument in eval_detection.py

### DIFF
--- a/eval/eval_detection.py
+++ b/eval/eval_detection.py
@@ -20,6 +20,7 @@ warnings.filterwarnings("ignore")
 parser = argparse.ArgumentParser()
 parser.add_argument('--dataname', type=str, default='adult')
 parser.add_argument('--model', type=str, default='real')
+parser.add_argument('--path', type=str, default = None, help='The file path of the synthetic data')
 
 args = parser.parse_args()
 
@@ -69,7 +70,11 @@ if __name__ == '__main__':
     dataname = args.dataname
     model = args.model
 
-    syn_path = f'synthetic/{dataname}/{model}.csv'
+    if not args.path:
+        syn_path = f'synthetic/{dataname}/{model}.csv'
+    else:
+        syn_path = args.path
+
     real_path = f'synthetic/{dataname}/real.csv'
 
     data_dir = f'data/{dataname}' 


### PR DESCRIPTION
The README usage of eval_detection.py includes the path argument, but this part is missing from the code.

Add path argument in eval_detection.py


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
