### PR TITLE
Fix ReduceLROnPlateau compatibility by updating installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ conda activate tabsyn
 
 Install pytorch
 ```
-pip install torch torchvision torchaudio
+pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
 ```
 
 or via conda


### PR DESCRIPTION
*Issue #, if available:*

ReduceLROnPlateau compatibility by updating installation instructions

*Description of changes:*

This PR updates the installation instructions in the README to ensure compatibility with the current implementation of `ReduceLROnPlateau` used in `tabsyn/tabsyn/vae/main.py`.

Newer versions of PyTorch have removed the `verbose` argument from `torch.optim.lr_scheduler.ReduceLROnPlateau`, which causes an error when running the training code.

### Solution

Instead of installing the latest version of PyTorch via:

```
pip install torch torchvision torchaudio
```

This PR updates the README to recommend installing specific compatible versions:

```
pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
```

This ensures the code runs without errors until the usage of `verbose` is updated in the codebase.

### Testing

Tested locally using the proposed versions and confirmed that the issue is resolved.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
