### PR TITLE
fix: use cpu only for sampling

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from utils import execute_function, get_args
 
 if __name__ == '__main__':
     args = get_args()
-    if torch.cuda.is_available():
+    if args.gpu != -1 and torch.cuda.is_available():
         args.device = f'cuda:{args.gpu}'
     else:
         args.device = 'cpu'

--- a/tabsyn/sample.py
+++ b/tabsyn/sample.py
@@ -26,7 +26,10 @@ def main(args):
     
     model = Model(denoise_fn = denoise_fn, hid_dim = train_z.shape[1]).to(device)
 
-    model.load_state_dict(torch.load(f'{ckpt_path}/model.pt'))
+    if device == 'cpu':
+        model.load_state_dict(torch.load(f'{ckpt_path}/model.pt', map_location='cpu'))
+    else:
+        model.load_state_dict(torch.load(f'{ckpt_path}/model.pt'))
 
     '''
         Generating samples    
@@ -36,7 +39,7 @@ def main(args):
     num_samples = train_z.shape[0]
     sample_dim = in_dim
 
-    x_next = sample(model.denoise_fn_D, num_samples, sample_dim)
+    x_next = sample(model.denoise_fn_D, num_samples, sample_dim, device=device)
     x_next = x_next * 2 + mean.to(device)
 
     syn_data = x_next.float().cpu().numpy()


### PR DESCRIPTION
*Issue #, if available:*

#40 

*Description of changes:*

Fixes CPU-only sampling functionality when using `--gpu -1` flag. The issue was caused by hardcoded CUDA device usage in the sampling pipeline.

**Changes made:**
- Modified `main.py` to properly handle `--gpu -1` for CPU-only execution
- Updated `tabsyn/sample.py` to pass device parameter to sampling function and handle CPU model loading
- Ensures backward compatibility while enabling CPU-only inference

**Testing:**
- ✅ CPU sampling: `python main.py --dataname shoppers --method tabsyn --mode sample --gpu -1`
- ✅ GPU sampling: `python main.py --dataname shoppers --method tabsyn --mode sample --gpu 0` (when available)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.